### PR TITLE
Fix/subscribe

### DIFF
--- a/alm-mqtt-module/example/subscribe/subscribe.go
+++ b/alm-mqtt-module/example/subscribe/subscribe.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 	client := client.NewClient("alm-mqtt-module", natsClient)
-	res, err := client.RegisterMqttTopic("simulation/temperature")
+	res, err := client.RegisterMqttTopic("climate/temperature")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Issue: 
If an application subscribes to a MQTT topic, these messages were received in request response handler `reqestResponseHandler`.

Solution:
At every new subscribe, register the handler `mqttHandler` as callback for the new topic.